### PR TITLE
Update rstest and fix running tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ repository = "https://github.com/astralbijection/newbase60-rs"
 description = "A library that implements Tantek Çelik's New Base 60"
 
 [dev-dependencies]
-rstest = "0.7.0"
+rstest = "0.18.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(tests)]
+#[cfg(test)]
 mod tests;
 
 /// Convert a number into its New Base 60 representation.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,5 @@
 use rstest::rstest;
+use super::*;
 
 // Tests stolen from https://github.com/indieweb/newBase60py/blob/master/newbase60test.py
 


### PR DESCRIPTION
When making #2 Rust gave me a warning that the version of rstest had something future-incompatible in it, so I updated it - and then I also fixed `cfg(tests)` to `cfg(test)` because `cargo test` wasn't actually running those 🤷